### PR TITLE
refactor open APK function and some renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Integrated [Quark-Engine](https://github.com/quark-engine/quark-engine) for Malware Analysis (thanks [Shaun Dang](https://github.com/pulorsok))
 - Integrated [apk-mitm](https://github.com/shroudedcode/apk-mitm) natively (thanks [Niklas Higi](https://github.com/shroudedcode))
-- Initialize decoded project directory as Git repo (thanks [Aman](https://github.com/amsharma44))
+- Initialize project directory as Git repo (thanks [Aman](https://github.com/amsharma44))
 - Add [**Smalise**](https://github.com/LoyieKing/Smalise) as an extension dependency
 - Various code-quality improvements and integration tests
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ APKLab seamlessly integrates the best open-source tools: <a href='https://github
 <details>
   <summary>Additional configuration</summary>
 
-- **`apklab.initDecodedDirAsGit`**: Initialize decoded APK directory as **Git** repository.
+- **`apklab.initProjectDirAsGit`**: Initialize project output directory as **Git** repository.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -186,10 +186,10 @@
                     "default": "",
                     "markdownDescription": "Put the **password** of the used key in the keystore here."
                 },
-                "apklab.initDecodedDirAsGit": {
+                "apklab.initProjectDirAsGit": {
                     "type": "boolean",
                     "default": "true",
-                    "markdownDescription": "Initialize decoded APK directory as **Git** repository."
+                    "markdownDescription": "Initialize project output directory as **Git** repository."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext): void {
         async () => {
             updateTools()
                 .then(async () => {
-                    UI.decompileAPK();
+                    UI.openApkFile();
                 })
                 .catch(() => {
                     outputChannel.appendLine(

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -91,7 +91,7 @@ export namespace UI {
                     await Quark.analyzeAPK(apkFilePath, projectDir);
                 }
 
-                // Initialize decoded dir as git repo
+                // Initialize project dir as git repo
                 await initGitDir(projectDir, "Initial APKLab project");
             }
         } else {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
-import { QuickPickItem, window } from "vscode";
+import { commands, QuickPickItem, Uri, window } from "vscode";
 import { apktool, initGitDir, jadx } from "./tools";
 import { outputChannel } from "./common";
 import { quickPickUtil } from "./quick-pick.util";
@@ -68,7 +68,7 @@ export namespace UI {
                     }
                 }
 
-                // project directory
+                // project directory name
                 const apkFilePath = result[0].fsPath;
                 let projectDir = path.join(
                     path.dirname(apkFilePath),
@@ -93,6 +93,15 @@ export namespace UI {
 
                 // Initialize project dir as git repo
                 await initGitDir(projectDir, "Initial APKLab project");
+
+                // open project dir in a new window
+                if (!process.env["TEST"]) {
+                    await commands.executeCommand(
+                        "vscode.openFolder",
+                        Uri.file(projectDir),
+                        true
+                    );
+                }
             }
         } else {
             outputChannel.appendLine("APKLAB: no APK file was chosen");

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -74,7 +74,7 @@ export namespace UI {
                     path.dirname(apkFilePath),
                     path.parse(apkFilePath).name
                 );
-                // don't delete the existing dir if it does exist
+                // don't delete the existing dir if it already exists
                 while (fs.existsSync(projectDir)) {
                     projectDir = projectDir + "1";
                 }

--- a/src/mitm-patches.ts
+++ b/src/mitm-patches.ts
@@ -23,10 +23,10 @@ export async function applyMitmPatches(apktoolYmlPath: string): Promise<void> {
             `Using apk-mitm v${APK_MITM_VERSION} (https://github.com/shroudedcode/apk-mitm)\n`
         );
 
-        const decodeDir = path.dirname(apktoolYmlPath);
+        const projectDir = path.dirname(apktoolYmlPath);
 
         await apkMitm
-            .observeListr(apkMitm.applyPatches(decodeDir))
+            .observeListr(apkMitm.applyPatches(projectDir))
             .forEach((line) => outputChannel.appendLine(line));
 
         outputChannel.appendLine("\nSuccessfully applied MITM patches!");

--- a/src/quark-tools.ts
+++ b/src/quark-tools.ts
@@ -278,13 +278,13 @@ export namespace Quark {
     /**
      * Analyzing APK using Quark-Engine.
      * @param apkFilePath The path of APK file.
-     * @param apkDecodedDir The path of the decoded directory.
+     * @param projectDir project output dir for decode/decompile/analysis.
      */
     export async function analyzeAPK(
         apkFilePath: string,
-        apkDecodedDir: string
+        projectDir: string
     ): Promise<void> {
-        const reportPath = path.join(apkDecodedDir, `quarkReport.json`);
+        const reportPath = path.join(projectDir, `quarkReport.json`);
         const script = `quark -a ${apkFilePath} -o ${reportPath}`;
 
         await vscode.window.withProgress(

--- a/src/quick-pick.util.ts
+++ b/src/quick-pick.util.ts
@@ -7,7 +7,7 @@ const quickPickItems: { [index: string]: QuickPickItem[] } = {
     rebuildQuickPickItems: [
         {
             label: "--use-aapt2",
-            detail: "Use the aapt2 binary instead of appt",
+            detail: "Use the aapt2 binary instead of aapt",
             alwaysShow: true,
             picked: true,
         },
@@ -78,13 +78,13 @@ const quickPickItems: { [index: string]: QuickPickItem[] } = {
 };
 
 export namespace quickPickUtil {
-    export function getQuickPickItems(catagory: string): QuickPickItem[] {
-        return quickPickItems[catagory];
+    export function getQuickPickItems(category: string): QuickPickItem[] {
+        return quickPickItems[category];
     }
 
-    export function setQuickPickDefault(catagory: string, label: string): void {
-        if (quickPickItems[catagory]) {
-            const targetOption = quickPickItems[catagory].filter(
+    export function setQuickPickDefault(category: string, label: string): void {
+        if (quickPickItems[category]) {
+            const targetOption = quickPickItems[category].filter(
                 (x) => x.label === label
             )[0];
             if (targetOption) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -79,7 +79,7 @@ describe("Extension Test Suite", function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
         const projectDir = path.resolve(simpleKeyboardDir, "test");
 
-        console.log(`Decoding ${testApkPath}...`);
+        console.log(`Analyzing ${testApkPath}...`);
         await Quark.analyzeAPK(testApkPath, projectDir);
 
         // Testing report generate

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -74,7 +74,7 @@ describe("Extension Test Suite", function () {
         });
     });
 
-    // Quark test unit
+    // test the Malware Analysis feature (uses Quark-Engine)
     it("Quark-engine Analysis", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
         const projectDir = path.resolve(simpleKeyboardDir, "test");
@@ -83,7 +83,7 @@ describe("Extension Test Suite", function () {
         console.log(`Analyzing ${testApkPath}...`);
         await Quark.analyzeAPK(testApkPath, projectDir);
 
-        // Testing report generate
+        // Testing report generation
         const reportJsonSamplePath = path.join(
             simpleKeyboardDir,
             "quark_report.json"

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -78,6 +78,7 @@ describe("Extension Test Suite", function () {
     it("Quark-engine Analysis", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
         const projectDir = path.resolve(simpleKeyboardDir, "test");
+        fs.mkdirSync(projectDir);
 
         console.log(`Analyzing ${testApkPath}...`);
         await Quark.analyzeAPK(testApkPath, projectDir);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,7 +2,8 @@ import * as assert from "assert";
 import * as path from "path";
 import * as fs from "fs";
 import { updateTools } from "../../downloader";
-import { apktool } from "../../tools";
+import { apktool, jadx } from "../../tools";
+import { Quark } from "../../quark-tools";
 
 describe("Extension Test Suite", function () {
     this.timeout(600000);
@@ -35,8 +36,9 @@ describe("Extension Test Suite", function () {
     // test the Decode feature (uses ApkTool)
     it("Decode SimpleKeyboard.apk", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
+        const projectDir = path.resolve(simpleKeyboardDir, "test");
         console.log(`Decoding ${testApkPath}...`);
-        await apktool.decodeAPK(testApkPath, [], false, false);
+        await apktool.decodeAPK(testApkPath, projectDir, []);
         const jsonFilePath = path.join(simpleKeyboardDir, "decoded_files.json");
         const jsonFileData = fs.readFileSync(jsonFilePath, "utf-8");
         const decodedFiles: string[] = JSON.parse(jsonFileData);
@@ -51,16 +53,17 @@ describe("Extension Test Suite", function () {
     // test the Decompile feature (uses Jadx)
     it("Decompile SimpleKeyboard.apk", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
+        const projectDir = path.resolve(simpleKeyboardDir, "test");
         console.log(`Decompiling ${testApkPath}...`);
-        await apktool.decodeAPK(testApkPath, [], true, false);
+        await jadx.decompileAPK(testApkPath, projectDir);
         const jsonFilePath = path.join(
             simpleKeyboardDir,
             "decompiled_files.json"
         );
         const jsonFileData = fs.readFileSync(jsonFilePath, "utf-8");
-        const decodedFiles: string[] = JSON.parse(jsonFileData);
+        const decompiledFiles: string[] = JSON.parse(jsonFileData);
         console.log("Comparing file list...");
-        decodedFiles.forEach((file) => {
+        decompiledFiles.forEach((file) => {
             if (
                 !fs.existsSync(
                     path.join(simpleKeyboardDir, "test", "java_src", file)
@@ -74,8 +77,10 @@ describe("Extension Test Suite", function () {
     // Quark test unit
     it("Quark-engine Analysis", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
+        const projectDir = path.resolve(simpleKeyboardDir, "test");
+
         console.log(`Decoding ${testApkPath}...`);
-        await apktool.decodeAPK(testApkPath, [], false, true);
+        await Quark.analyzeAPK(testApkPath, projectDir);
 
         // Testing report generate
         const reportJsonSamplePath = path.join(
@@ -105,8 +110,10 @@ describe("Extension Test Suite", function () {
     // test the Rebuild & Sign feature (uses ApkTool & uber-apk-signer)
     it("Rebuild SimpleKeyboard.apk", async function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
+        const projectDir = path.resolve(simpleKeyboardDir, "test");
+
         console.log(`Decoding ${testApkPath}...`);
-        await apktool.decodeAPK(testApkPath, [], false, false);
+        await apktool.decodeAPK(testApkPath, projectDir, []);
         const apktoolYmlPath = path.resolve(
             simpleKeyboardDir,
             "test",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { extensionConfigName, outputChannel } from "./common";
-import { Quark } from "./quark-tools";
+
 /**
  * Options for executeProcess function.
  */
@@ -50,7 +50,7 @@ function getApkName(apktoolYamlPath: string) {
         return regArr && regArr.length > 0 ? regArr[0].split(": ")[1] : "";
     } catch (err) {
         outputChannel.appendLine(
-            "couldn't find apkFileName in apktool.yml: " + String(err)
+            "Couldn't find apkFileName in apktool.yml: " + String(err)
         );
         return "";
     }
@@ -139,24 +139,29 @@ function executeProcess(processOptions: ProcessOptions): Thenable<void> {
 }
 
 /**
- * Initialize a direcotry as **Git** repository.
- * @param dirPath Directory path for repository.
+ * Initialize a directory as **Git** repository.
+ * @param projectDir project output dir for decode/decompile/analysis.
  * @param commitMsg Message for initial commit.
  */
 export async function initGitDir(
-    dirPath: string,
+    projectDir: string,
     commitMsg: string
 ): Promise<void> {
+    const extensionConfig = vscode.workspace.getConfiguration(
+        extensionConfigName
+    );
+    const initializeGit = extensionConfig.get("initProjectDirAsGit");
+    if (!initializeGit) return;
     try {
         // .gitignore content
         const gitignore = "/build\n/dist\n";
         await fs.promises.writeFile(
-            path.join(dirPath, ".gitignore"),
+            path.join(projectDir, ".gitignore"),
             gitignore
         );
-        let initCmd = `cd "${dirPath}" && git init && git config core.safecrlf false`;
+        let initCmd = `cd "${projectDir}" && git init && git config core.safecrlf false`;
         initCmd += ` && git add -A && git commit -q -m "${commitMsg}"`;
-        const report = `Initializing ${dirPath} as Git repository`;
+        const report = `Initializing ${projectDir} as Git repository`;
         await executeProcess({
             name: "Initializing Git",
             report: report,
@@ -166,7 +171,7 @@ export async function initGitDir(
         });
     } catch (err) {
         outputChannel.appendLine(
-            `Error: Initializing decoded dir as Git repository: ${err.message}`
+            `Error: Initializing project dir as Git repository: ${err.message}`
         );
     }
 }
@@ -175,43 +180,33 @@ export namespace apktool {
     /**
      * Decodes(Disassembles) the apk resources & dalvik bytecode using **Apktool**.
      * @param apkFilePath file path Uri for apk file to decode.
+     * @param projectDir project output dir for decode/decompile/analysis.
      * @param apktoolArgs array of additional args passed to **Apktool**.
-     * @param decompileJava if **jadx** needs to decompile the APK.
-     * @param quarkAnalysis if **Quark-Engine** analyze APK.
      */
     export async function decodeAPK(
         apkFilePath: string,
-        apktoolArgs: string[],
-        decompileJava: boolean,
-        quarkAnalysis: boolean
+        projectDir: string,
+        apktoolArgs: string[]
     ): Promise<void> {
         const extensionConfig = vscode.workspace.getConfiguration(
             extensionConfigName
         );
         const apktoolPath = extensionConfig.get("apktoolPath");
         const apkFileName = path.basename(apkFilePath);
-        const initializeGit = extensionConfig.get("initDecodedDirAsGit");
-        let apkDecodeDir = path.join(
-            path.dirname(apkFilePath),
-            path.parse(apkFilePath).name
-        );
-        // don't delete the existing dir if it does exist
-        while (fs.existsSync(apkDecodeDir)) {
-            apkDecodeDir = apkDecodeDir + "1";
-        }
-        const report = `Decoding ${apkFileName} into ${apkDecodeDir}`;
+
+        const report = `Decoding ${apkFileName} into ${projectDir}`;
         let args = [
             "-jar",
             String(apktoolPath),
             "d",
             apkFilePath,
             "-o",
-            apkDecodeDir,
+            projectDir,
         ];
         if (apktoolArgs && apktoolArgs.length > 0) {
             args = args.concat(apktoolArgs);
         }
-        const shouldExist = path.join(apkDecodeDir, "apktool.yml");
+        const shouldExist = path.join(projectDir, "apktool.yml");
         await executeProcess({
             name: "Decoding",
             report: report,
@@ -219,28 +214,11 @@ export namespace apktool {
             args: args,
             shouldExist: shouldExist,
             onSuccess: async () => {
-                if (decompileJava) {
-                    await jadx.decompileAPK(
-                        apkFilePath,
-                        apkFileName,
-                        apkDecodeDir
-                    );
-                }
-                // quark analysis
-                if (quarkAnalysis) {
-                    await Quark.analyzeAPK(apkFilePath, apkDecodeDir);
-                }
-
-                // Initialize decoded dir as git repo
-                if (initializeGit) {
-                    await initGitDir(apkDecodeDir, "Initial APK decode");
-                }
-
                 // open apkDecodeDir in a new vs code window
                 if (!process.env["TEST"]) {
                     await vscode.commands.executeCommand(
                         "vscode.openFolder",
-                        vscode.Uri.file(apkDecodeDir),
+                        vscode.Uri.file(projectDir),
                         true
                     );
                 }
@@ -390,13 +368,11 @@ export namespace jadx {
     /**
      * Decompile the APK file to Java source using **Jadx**.
      * @param apkFilePath path of the APK file.
-     * @param apkFileName name of the APK file.
-     * @param apkDecodeDir dir where the APK file was decoded.
+     * @param projectDir project output dir for decode/decompile/analysis.
      */
     export async function decompileAPK(
         apkFilePath: string,
-        apkFileName: string,
-        apkDecodeDir: string
+        projectDir: string
     ): Promise<void> {
         const extensionConfig = vscode.workspace.getConfiguration(
             extensionConfigName
@@ -406,7 +382,8 @@ export namespace jadx {
             process.platform.startsWith("win") ? ".bat" : ""
         }`;
         const jadxPath = path.join(String(jadxDirPath), "bin", jadxExeName);
-        const apkDecompileDir = path.join(apkDecodeDir, "java_src");
+        const apkDecompileDir = path.join(projectDir, "java_src");
+        const apkFileName = path.basename(apkFilePath);
         const report = `Decompiling ${apkFileName} into ${apkDecompileDir}`;
         const args = ["-r", "-v", "-ds", apkDecompileDir, apkFilePath];
         await executeProcess({

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -375,7 +375,7 @@ export namespace jadx {
         const apkDecompileDir = path.join(projectDir, "java_src");
         const apkFileName = path.basename(apkFilePath);
         const report = `Decompiling ${apkFileName} into ${apkDecompileDir}`;
-        const args = ["-r", "-v", "-ds", apkDecompileDir, apkFilePath];
+        const args = ["-r", "-q", "-v", "-ds", apkDecompileDir, apkFilePath];
         await executeProcess({
             name: "Decompiling",
             report: report,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -213,16 +213,6 @@ export namespace apktool {
             command: "java",
             args: args,
             shouldExist: shouldExist,
-            onSuccess: async () => {
-                // open apkDecodeDir in a new vs code window
-                if (!process.env["TEST"]) {
-                    await vscode.commands.executeCommand(
-                        "vscode.openFolder",
-                        vscode.Uri.file(projectDir),
-                        true
-                    );
-                }
-            },
         });
     }
 


### PR DESCRIPTION
This PR:
1. Removes decompile, analysis & git-init functions from decode's callback.
2. Fixes tests after 1.
3. Defines output dir as `Project Dir`.
4. Renames configuration item `initDecodedDirAsGit` to `initProjectDirAsGit`.
5. Does some other renaming & typo fixes
6. Run Jadx in `--quite` mode