### PR TITLE
Add deobfuscation args to jadx

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -54,7 +54,7 @@ export namespace UI {
                 let quarkAnalysis = false;
                 let jadxArgs: string[] = [];
                 if (jadxOptionsIndex > -1) {
-                    jadxArgs = args.splice(jadxOptionsIndex);
+                    jadxArgs = args.splice(jadxOptionsIndex, 1);
                 }
                 if (decompileJavaIndex > -1) {
                     decompileJava = true;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,7 +24,9 @@ export namespace UI {
             matchOnDescription: true,
             ignoreFocusOut: true,
         });
-        return result ? result.map<string>((item) => item.label) : undefined;
+        return result
+            ? result.map<string>((item) => item.label.split(" ")[0])
+            : undefined;
     }
 
     /**
@@ -47,9 +49,17 @@ export namespace UI {
             if (args) {
                 const decompileJavaIndex = args.indexOf("decompile_java");
                 const quarkAnalysisIndex = args.indexOf("quark_analysis");
+                const jadxOptionsIndex = args.indexOf("--deobf");
                 let decompileJava = false;
                 let quarkAnalysis = false;
                 let jadxArgs: string[] = [];
+                if (jadxOptionsIndex > -1) {
+                    jadxArgs = args.splice(jadxOptionsIndex);
+                }
+                if (decompileJavaIndex > -1) {
+                    decompileJava = true;
+                    args.splice(decompileJavaIndex, 1);
+                }
                 if (quarkAnalysisIndex > -1) {
                     quarkAnalysis = true;
                     args.splice(quarkAnalysisIndex, 1);
@@ -63,11 +73,6 @@ export namespace UI {
                         );
                         return;
                     }
-                }
-                if (decompileJavaIndex > -1) {
-                    decompileJava = true;
-                    args.splice(decompileJavaIndex, 1);
-                    jadxArgs = args.splice(decompileJavaIndex);
                 }
 
                 // project directory name

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -49,10 +49,7 @@ export namespace UI {
                 const quarkAnalysisIndex = args.indexOf("quark_analysis");
                 let decompileJava = false;
                 let quarkAnalysis = false;
-                if (decompileJavaIndex > -1) {
-                    decompileJava = true;
-                    args.splice(decompileJavaIndex, 1);
-                }
+                let jadxArgs: string[] = [];
                 if (quarkAnalysisIndex > -1) {
                     quarkAnalysis = true;
                     args.splice(quarkAnalysisIndex, 1);
@@ -66,6 +63,11 @@ export namespace UI {
                         );
                         return;
                     }
+                }
+                if (decompileJavaIndex > -1) {
+                    decompileJava = true;
+                    args.splice(decompileJavaIndex, 1);
+                    jadxArgs = args.splice(decompileJavaIndex);
                 }
 
                 // project directory name
@@ -84,7 +86,7 @@ export namespace UI {
 
                 // decompile APK
                 if (decompileJava) {
-                    await jadx.decompileAPK(apkFilePath, projectDir);
+                    await jadx.decompileAPK(apkFilePath, projectDir, jadxArgs);
                 }
                 // quark analysis
                 if (quarkAnalysis) {

--- a/src/quick-pick.util.ts
+++ b/src/quick-pick.util.ts
@@ -40,11 +40,6 @@ const quickPickItems: { [index: string]: QuickPickItem[] } = {
             description: "[Use Quark-Engine]",
         },
         {
-            label: "decompile_java",
-            detail: "Decompiles APK to Java source using Jadx",
-            description: "[Use Jadx]",
-        },
-        {
             label: "--no-src",
             detail: "Do not decompile dex to smali (-s)",
             alwaysShow: true,
@@ -73,6 +68,35 @@ const quickPickItems: { [index: string]: QuickPickItem[] } = {
             label: "--no-debug-info",
             detail:
                 "Prevents baksmali from writing out debug info (.local, .param, .line, etc). (-b)",
+        },
+        {
+            label: "decompile_java",
+            detail: "Decompiles APK to Java source using Jadx",
+            description: "[Use Jadx]",
+        },
+        {
+            label: "--deobf",
+            detail: "Activate deobfuscation for Jadx",
+            alwaysShow: true,
+        },
+        {
+            label: "--deobf-min",
+            detail:
+                "Set the minimal length of name during deobfuscation, renamed if shorter, default: 3",
+        },
+        {
+            label: "--deobf-max",
+            detail:
+                "Set the maximal length of name during deobfuscation, renamed if longer, default: 64",
+        },
+        {
+            label: "--deobf-rewrite-cfg",
+            detail: "Force to save deobfuscation map",
+        },
+        {
+            label: "--deobf-use-sourcename",
+            detail:
+                "Use source file name as class name alias during deobfuscation",
         },
     ],
 };

--- a/src/quick-pick.util.ts
+++ b/src/quick-pick.util.ts
@@ -40,63 +40,44 @@ const quickPickItems: { [index: string]: QuickPickItem[] } = {
             description: "[Use Quark-Engine]",
         },
         {
-            label: "--no-src",
-            detail: "Do not decompile dex to smali (-s)",
-            alwaysShow: true,
-        },
-        {
-            label: "--no-res",
-            detail: "Do not decompile resources (-r)",
-            alwaysShow: true,
-        },
-        {
-            label: "--force-manifest",
-            detail:
-                "Forces decode of AndroidManifest regardless of decoding of resources flag.",
-        },
-        {
-            label: "--no-assets",
-            detail: "Prevents decoding/copying of unknown asset files.",
-            alwaysShow: true,
-        },
-        {
-            label: "--only-main-classes",
-            detail: "Only disassemble dex classes in root (classes[0-9]*.dex)",
-            picked: true,
-        },
-        {
-            label: "--no-debug-info",
-            detail:
-                "Prevents baksmali from writing out debug info (.local, .param, .line, etc). (-b)",
-        },
-        {
             label: "decompile_java",
             detail: "Decompiles APK to Java source using Jadx",
             description: "[Use Jadx]",
         },
         {
-            label: "--deobf",
-            detail: "Activate deobfuscation for Jadx",
+            label: "--no-src (apktool)",
+            detail: "Do not decompile dex to smali (-s)",
             alwaysShow: true,
         },
         {
-            label: "--deobf-min",
-            detail:
-                "Set the minimal length of name during deobfuscation, renamed if shorter, default: 3",
+            label: "--no-res (apktool)",
+            detail: "Do not decompile resources (-r)",
+            alwaysShow: true,
         },
         {
-            label: "--deobf-max",
+            label: "--force-manifest (apktool)",
             detail:
-                "Set the maximal length of name during deobfuscation, renamed if longer, default: 64",
+                "Forces decode of AndroidManifest regardless of decoding of resources flag.",
         },
         {
-            label: "--deobf-rewrite-cfg",
-            detail: "Force to save deobfuscation map",
+            label: "--no-assets (apktool)",
+            detail: "Prevents decoding/copying of unknown asset files.",
+            alwaysShow: true,
         },
         {
-            label: "--deobf-use-sourcename",
+            label: "--only-main-classes (apktool)",
+            detail: "Only disassemble dex classes in root (classes[0-9]*.dex)",
+            picked: true,
+        },
+        {
+            label: "--no-debug-info (apktool)",
             detail:
-                "Use source file name as class name alias during deobfuscation",
+                "Prevents baksmali from writing out debug info (.local, .param, .line, etc). (-b)",
+        },
+        {
+            label: "--deobf (jadx)",
+            detail: "Activate deobfuscation for Jadx",
+            alwaysShow: true,
         },
     ],
 };

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -55,7 +55,7 @@ describe("Extension Test Suite", function () {
         const testApkPath = path.resolve(simpleKeyboardDir, "test.apk");
         const projectDir = path.resolve(simpleKeyboardDir, "test");
         console.log(`Decompiling ${testApkPath}...`);
-        await jadx.decompileAPK(testApkPath, projectDir);
+        await jadx.decompileAPK(testApkPath, projectDir, []);
         const jsonFilePath = path.join(
             simpleKeyboardDir,
             "decompiled_files.json"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -359,10 +359,12 @@ export namespace jadx {
      * Decompile the APK file to Java source using **Jadx**.
      * @param apkFilePath path of the APK file.
      * @param projectDir project output dir for decode/decompile/analysis.
+     * @param jadxArgs array of additional args passed to **Jadx**.
      */
     export async function decompileAPK(
         apkFilePath: string,
-        projectDir: string
+        projectDir: string,
+        jadxArgs: string[]
     ): Promise<void> {
         const extensionConfig = vscode.workspace.getConfiguration(
             extensionConfigName
@@ -375,7 +377,10 @@ export namespace jadx {
         const apkDecompileDir = path.join(projectDir, "java_src");
         const apkFileName = path.basename(apkFilePath);
         const report = `Decompiling ${apkFileName} into ${apkDecompileDir}`;
-        const args = ["-r", "-q", "-v", "-ds", apkDecompileDir, apkFilePath];
+        let args = ["-r", "-q", "-v", "-ds", apkDecompileDir, apkFilePath];
+        if (jadxArgs && jadxArgs.length > 0) {
+            args = jadxArgs.concat(args);
+        }
         await executeProcess({
             name: "Decompiling",
             report: report,


### PR DESCRIPTION
As the title says.

Add all options for deobfuscation in the drop-down menu when opening an APK.