### PR TITLE
show quark analysis report on project open

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 import { outputChannel } from "./data/constants";
 import { updateTools } from "./utils/downloader";
@@ -88,4 +90,17 @@ export function activate(context: vscode.ExtensionContext): void {
         emptyFrameworkDirCommand,
         quarkReportCommand
     );
+
+    // check if open folder contains `quarkReport.json` file
+    // if it exists, show it as a report on open
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length > 0) {
+        const quarkReportFile = path.join(
+            folders[0].uri.fsPath,
+            "quarkReport.json"
+        );
+        if (fs.existsSync(quarkReportFile)) {
+            Quark.showSummaryReport(quarkReportFile);
+        }
+    }
 }

--- a/src/tools/quark-engine.ts
+++ b/src/tools/quark-engine.ts
@@ -294,9 +294,6 @@ export namespace Quark {
             command: "quark",
             args: ["-a", apkFilePath, "-o", jsonReportPath],
             shouldExist: jsonReportPath,
-            onSuccess: () => {
-                showSummaryReport(jsonReportPath);
-            },
         });
     }
 


### PR DESCRIPTION
This PR enables quark-analysis report webview to show up on opening a project with `quarkReport.json` file in its root. This fixes the issue when this webview was being opened in the previous window after analysis was finished.