### PR TITLE
use common process executor for quark analysis

### DIFF
--- a/src/tools/quark-engine.ts
+++ b/src/tools/quark-engine.ts
@@ -288,14 +288,11 @@ export namespace Quark {
     ): Promise<void> {
         const jsonReportPath = path.join(projectDir, `quarkReport.json`);
 
-        const report = `Analyzing ${apkFilePath}`;
-        const args = ["-a", apkFilePath, "-o", jsonReportPath];
-
         await executeProcess({
             name: "Quark analysis",
-            report: report,
+            report: `Analyzing ${apkFilePath}`,
             command: "quark",
-            args: args,
+            args: ["-a", apkFilePath, "-o", jsonReportPath],
             shouldExist: jsonReportPath,
             onSuccess: () => {
                 showSummaryReport(jsonReportPath);

--- a/src/tools/quark-engine.ts
+++ b/src/tools/quark-engine.ts
@@ -297,6 +297,9 @@ export namespace Quark {
             command: "quark",
             args: args,
             shouldExist: jsonReportPath,
+            onSuccess: () => {
+                showSummaryReport(jsonReportPath);
+            },
         });
     }
 

--- a/src/utils/executor.ts
+++ b/src/utils/executor.ts
@@ -98,7 +98,9 @@ export function executeProcess(processOptions: ProcessOptions): Thenable<void> {
                         }
                     } else {
                         outputChannel.appendLine(
-                            `${processOptions.name} process exited with code ${code}`
+                            code !== 0
+                                ? `${processOptions.name} process exited with code ${code}`
+                                : `${processOptions.name} process didn't create ${processOptions.shouldExist}`
                         );
                         vscode.window.showErrorMessage(
                             `APKLab: ${processOptions.name} process failed.`


### PR DESCRIPTION
This PR:
- cleans up the duplicate process execution code for Quark analysis
- clarifies the reason for a process failure.