### PR TITLE
apk-mitm: set debuggable=true

### DIFF
--- a/src/tools/apk-mitm.ts
+++ b/src/tools/apk-mitm.ts
@@ -28,7 +28,7 @@ export namespace apkMitm {
 
             const projectDir = path.dirname(apktoolYmlPath);
 
-            await observeListr(applyPatches(projectDir)).forEach((line) =>
+            await observeListr(applyPatches(projectDir, true)).forEach((line) =>
                 outputChannel.appendLine(line)
             );
 


### PR DESCRIPTION
When applying the MITM patches I'd like to also make the app debuggable, like `apk-mitm --debuggable` does. This is a very simple way to achieve that.

Other ways to implement this might be adding a configuration option to set this behavior, or adding a new context menu entry for just setting the debuggable flag. However, I see no downside in making any MITM patched apk debuggable too.