### PR TITLE
Swap out child_spawn with cross-spawn to address windows jadx path space

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
         "watch": "webpack --watch"
     },
     "devDependencies": {
+        "@types/cross-spawn": "^6.0.2",
         "@types/glob": "^8.1.0",
         "@types/listr": "^0.14.4",
         "@types/mocha": "^10.0.1",
@@ -254,6 +255,7 @@
     },
     "dependencies": {
         "apk-mitm": "^1.2.1",
+        "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1"
     }
 }

--- a/src/utils/executor.ts
+++ b/src/utils/executor.ts
@@ -1,5 +1,5 @@
-import * as child_process from "child_process";
 import * as fs from "fs";
+import * as cross_spawn from "cross-spawn";
 import * as vscode from "vscode";
 import { outputChannel } from "../data/constants";
 
@@ -60,7 +60,7 @@ export function executeProcess(processOptions: ProcessOptions): Thenable<void> {
             return new Promise<void>((resolve) => {
                 progress.report({ message: processOptions.report });
 
-                const cp = child_process.spawn(
+                const cp = cross_spawn.spawn(
                     processOptions.command,
                     processOptions.args,
                     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,13 @@
   resolved "https://registry.yarnpkg.com/@tybys/oid/-/oid-3.0.0.tgz#ee581f2d23d631a049312d1049c54f9b4334983c"
   integrity sha512-sRsDzqzxsinQV4Ewl65trK45qjINNRh6/iFn/Wil+cab4l5rFy8sQu7OfRL2LNIuLPvVXG/lsVqKvsuMLo5Ttw==
 
+"@types/cross-spawn@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
+  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -3173,6 +3180,7 @@ source-map@^0.6.0:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3698,6 +3706,7 @@ workerpool@6.2.1:
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR replaces the NodeJS default child_spawn module with [cross-spawn](https://www.npmjs.com/package/cross-spawn) due to command given to child_process.spawn failing if it has a spaces in it https://github.com/nodejs/node/issues/7367.

### Why?
Cross-spawn automatically [handles commands with spaces](https://github.com/moxystudio/node-cross-spawn#why).
This issue could be resolved by enabling shell and quoting the command but then we'd have to be responsible for command and argument input sanitization.

I've tested that this resolves issue https://github.com/APKLab/APKLab/issues/193 for me on Windows, I've also briefly verified that decompiling an APK and setting up the default git repository still works on a Ubuntu and Catalina machine.